### PR TITLE
Hide demo page content from screen reader when checkout is initiated

### DIFF
--- a/ada.html
+++ b/ada.html
@@ -119,6 +119,7 @@ function initiateCheckout() {
         "tax_amount": 30000,
         "total": 30000
     };
+    document.body.setAttribute('aria-hidden', 'true');
     affirm.checkout(checkout_object);
     affirm.checkout.open(
         {


### PR DESCRIPTION
- Issue: Mobile screen readers still able to pick up demo page elements when checkout iFrame is open
- Fix: set`aria-hidden` to `true` on the example page's document body when checkout is initiated